### PR TITLE
Updated for current version of Contracts gem.

### DIFF
--- a/lib/rubycheck.rb
+++ b/lib/rubycheck.rb
@@ -12,7 +12,6 @@ include Contracts
 # and encourages monkeypatching for defining generators for custom types.
 #
 module RubyCheck
-  include Contracts::Modules
 
   Contract nil => Bool
   #

--- a/rubycheck.gemspec
+++ b/rubycheck.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new { |s|
 
   s.required_ruby_version = '>= 1.9'
 
-  s.add_dependency 'contracts', '~> 0.8'
+  s.add_dependency 'contracts', '~> 0.10.1'
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'reek', '~> 1.3'


### PR DESCRIPTION
My system had the latest Contracts gem installed. An unmodified rubycheck fails tests.

    $ gem list contracts
    *** LOCAL GEMS ***
    contracts (0.10.1)
    $ rake test
    rake aborted!
    NameError: uninitialized constant Contracts::Modules
    ...

This change to contracts is documented here:
https://github.com/egonSchiele/contracts.ruby/commit/2ff320e8d2655b6791ffb01393eb3d51ca7197aa

I have made the required correction. As this may cause issues for users of the older Contracts gem, I also bumped the version requirement to keep things compatible.
