### PR TITLE
Uint16 generator

### DIFF
--- a/lib/rubycheck.rb
+++ b/lib/rubycheck.rb
@@ -54,6 +54,19 @@ module RubyCheck
 
   Contract nil => Integer
   #
+  # Generate a random unsigned integer in [0, 2^16 - 1].
+  #
+  # Example:
+  #
+  #   RubyCheck::gen_uint16
+  #   => 4
+  #
+  def self.gen_uint16
+    Random.rand(65535).to_i
+  end
+
+  Contract nil => Integer
+  #
   # Generate a random integer in [(-1 * 10^10) + 1, 10^10 - 1].
   #
   # Example:

--- a/lib/rubycheck.rb
+++ b/lib/rubycheck.rb
@@ -12,7 +12,6 @@ include Contracts
 # and encourages monkeypatching for defining generators for custom types.
 #
 module RubyCheck
-  include Contracts::Modules
 
   Contract nil => Bool
   #

--- a/rubycheck.gemspec
+++ b/rubycheck.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new { |s|
 
   s.required_ruby_version = '>= 1.9'
 
-  s.add_dependency 'contracts', '~> 0.8'
+  s.add_dependency 'contracts', '~> 0.10.1'
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'reek', '~> 1.3'

--- a/spec/rubycheck_spec.rb
+++ b/spec/rubycheck_spec.rb
@@ -54,6 +54,26 @@ describe RubyCheck, '#gen_uint' do
   end
 end
 
+describe RubyCheck, '#gen_uint16' do
+  it 'generates random unsigned integers' do
+    expect(RubyCheck.gen_uint16.class).to eq(Fixnum)
+
+    expect(1.upto(100).map { || RubyCheck.gen_uint16 }.uniq.length).to be > 10
+
+    module RubyCheck
+      def self.gen_uint16_array
+        gen_array(:gen_uint16)
+      end
+    end
+
+    prop_contains_some_positives = -> a { a.select { |i| i > 0 }.length > 0 }
+    prop_contains_some_negatives = -> a { a.select { |i| i < 0 }.length > 0 }
+
+    expect(RubyCheck.for_all(prop_contains_some_positives, [:gen_uint16_array])).to be true
+    expect(RubyCheck.for_all(prop_contains_some_negatives, [:gen_uint16_array]).class).to eq(Array)
+  end
+end
+
 describe RubyCheck, '#gen_byte' do
   it 'generates random bytes' do
     expect(RubyCheck.gen_byte.class).to eq(Fixnum)


### PR DESCRIPTION
I've found every test case I wrote using gen_uint triggered the OOM killer and crashed my test cases. This is generally dependant on your function trying to build arrays of 'x' length.

This generates smaller numbers which corrects that problem, for people affected.